### PR TITLE
Fixed TailwindCSS compilation crash caused by unescaped `/`

### DIFF
--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -47,7 +47,7 @@
   content: "\f09b";
 }
 
-// insert fontawesome.css from here
+/* insert fontawesome.css from here */
 
 .fa {
   font-family: var(--fa-style-family, "Font Awesome 6 Pro");


### PR DESCRIPTION
Fixed this error when running `mix dev.storybook`

```
> phx_live_storybook@1.0.0 build:fonts_css
> tailwindcss --minify -i css/fonts.css -o ../priv/static/css/fonts.css

node:internal/process/promises:245
          triggerUncaughtException(err, true /* fromPromise */);
          ^

Error: Unexpected '/'. Escaping special characters with \ may help.
    at /Users/matthieuchabert/Documents/workspace/phx_live_storybook/assets/css/fonts.css:50:1
```