### PR TITLE
Storybook generator fix

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  content: ["../lib/**/*.{ex,heex}", "./js/**/*.js"],
+  content: ["../lib/**/*.{ex,heex}", "./js/**/*.js", "../priv/templates/**/*.eex"],
   safelist: [
     { pattern: /^lsb-(w|h|m|p)-.+/ },
     {

--- a/lib/mix/tasks/phx.gen.storybook.ex
+++ b/lib/mix/tasks/phx.gen.storybook.ex
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.Phx.Gen.Storybook do
   The generated files will contain:
 
     * the storybook backend in `lib/my_app_web/storybook.ex`
-    * a dummy component in `storybook/components/my_component.story.exs`
+    * a dummy component in `storybook/components/icon.story.exs`
     * a dummy page in `storybook/my_page.story.exs`
     * a custom js in `assets/js/storybook.js`
     * a custom css in `assets/css/storybook.css`
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Phx.Gen.Storybook do
 
     mapping = [
       {"storybook.ex.eex", Path.join(app_folder, "storybook.ex")},
-      {"my_component.story.exs.eex", Path.join(component_folder, "my_component.story.exs")},
+      {"icon.story.exs.eex", Path.join(component_folder, "icon.story.exs")},
       {"my_page.story.exs.eex", Path.join(page_folder, "my_page.story.exs")},
       {"storybook.js.eex", Path.join(js_folder, "storybook.js")}
     ]

--- a/priv/templates/phx.gen.storybook/icon.story.exs.eex
+++ b/priv/templates/phx.gen.storybook/icon.story.exs.eex
@@ -1,12 +1,10 @@
-defmodule Storybook.Components.MyComponent do
+defmodule Storybook.Components.Icon do
   # See https://hexdocs.pm/phx_live_storybook/PhxLiveStorybook.Story.html for full story
   # documentation.
   # Read https://hexdocs.pm/phx_live_storybook/components.html for more advanced options.
 
   use PhxLiveStorybook.Story, :component
 
-  # This is a dummy fonction that you should replace with your own component function:
-  # def function, do: &MyButton.my_button/1
   def function, do: &PhxLiveStorybook.Components.Icon.hero_icon/1
 
   # A variation captures the rendered state of a UI component. Developers write multiple variations
@@ -17,21 +15,21 @@ defmodule Storybook.Components.MyComponent do
         id: :default,
         attributes: %{
           name: "calendar",
-          class: "lsb lsb-w-8 lsb-h-8"
+          class: "lsb-w-8 lsb-h-8"
         }
       },
       %Variation{
         id: :icon_variation,
         attributes: %{
           name: "bookmark",
-          class: "lsb lsb-w-8 lsb-h-8 lsb-text-red-500"
+          class: "lsb-w-8 lsb-h-8 lsb-text-red-500"
         }
       },
       %VariationGroup{
         id: :group,
         variations: [
-          %Variation{id: :item_1, attributes: %{name: "cake", class: "lsb lsb-w-8 lsb-h-8"}},
-          %Variation{id: :item_2, attributes: %{name: "cake", class: "lsb lsb-w-16 lsb-h-16"}},
+          %Variation{id: :item_1, attributes: %{name: "cake", class: "lsb-w-8 lsb-h-8"}},
+          %Variation{id: :item_2, attributes: %{name: "cake", class: "lsb-w-16 lsb-h-16"}},
         ]
       }
     ]

--- a/priv/templates/phx.gen.storybook/my_component.story.exs.eex
+++ b/priv/templates/phx.gen.storybook/my_component.story.exs.eex
@@ -7,11 +7,7 @@ defmodule Storybook.Components.MyComponent do
 
   # This is a dummy fonction that you should replace with your own component function:
   # def function, do: &MyButton.my_button/1
-  def function, do: &my_component/1
-
-  def my_component(assigns) do
-    ~H"<span><%=@text%></span>"
-  end
+  def function, do: &PhxLiveStorybook.Components.Icon.hero_icon/1
 
   # A variation captures the rendered state of a UI component. Developers write multiple variations
   # per component that describe all the “interesting” states a component can support.
@@ -20,20 +16,22 @@ defmodule Storybook.Components.MyComponent do
       %Variation{
         id: :default,
         attributes: %{
-          text: "Hello World"
+          name: "calendar",
+          class: "lsb lsb-w-8 lsb-h-8"
         }
       },
       %Variation{
-        id: :text_variation,
+        id: :icon_variation,
         attributes: %{
-          text: "A text variation"
+          name: "bookmark",
+          class: "lsb lsb-w-8 lsb-h-8 lsb-text-red-500"
         }
       },
       %VariationGroup{
         id: :group,
         variations: [
-          %Variation{id: :item_1, attributes: %{text: "item 1"}},
-          %Variation{id: :item_2, attributes: %{text: "item 2"}},
+          %Variation{id: :item_1, attributes: %{name: "cake", class: "lsb lsb-w-8 lsb-h-8"}},
+          %Variation{id: :item_2, attributes: %{name: "cake", class: "lsb lsb-w-16 lsb-h-16"}},
         ]
       }
     ]

--- a/priv/templates/phx.gen.storybook/my_component.story.exs.eex
+++ b/priv/templates/phx.gen.storybook/my_component.story.exs.eex
@@ -7,7 +7,11 @@ defmodule Storybook.Components.MyComponent do
 
   # This is a dummy fonction that you should replace with your own component function:
   # def function, do: &MyButton.my_button/1
-  def function, do: fn assigns -> ~H"<span><%=@text%></span>" end
+  def function, do: &my_component/1
+
+  def my_component(assigns) do
+    ~H"<span><%=@text%></span>"
+  end
 
   # A variation captures the rendered state of a UI component. Developers write multiple variations
   # per component that describe all the “interesting” states a component can support.

--- a/test/mix/tasks/phx.gen.storybook_test.exs
+++ b/test/mix/tasks/phx.gen.storybook_test.exs
@@ -16,14 +16,14 @@ defmodule Mix.Tasks.Phx.Gen.StorybookTest do
       for _ <- 1..5, do: send(self(), {:mix_shell_input, :yes?, true})
       Storybook.run([])
 
-      [{story, _}] = Code.compile_file("storybook/components/my_component.story.exs")
+      [{story, _}] = Code.compile_file("storybook/components/icon.story.exs")
       assert story.storybook_type() == :component
 
       [{page, _}] = Code.compile_file("storybook/my_page.story.exs")
       assert page.storybook_type() == :page
 
       [{backend, _}] = Code.compile_file("lib/phx_live_storybook_web/storybook.ex")
-      assert backend.storybook_path(story) == "/components/my_component"
+      assert backend.storybook_path(story) == "/components/icon"
       assert backend.config(:otp_app) == :phx_live_storybook_web
       assert backend.config(:sandbox_class) == "phx-live-storybook-web"
 
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Phx.Gen.StorybookTest do
 
       assert_shell_receive :info, ~r|Starting storybook generation|
       assert_shell_receive :info, ~r|creating lib/phx_live_storybook_web/storybook.ex|
-      assert_shell_receive :info, ~r|creating storybook/components/my_component.story.exs|
+      assert_shell_receive :info, ~r|creating storybook/components/icon.story.exs|
       assert_shell_receive :info, ~r|creating storybook/my_page.story.exs|
       assert_shell_receive :info, ~r|creating assets/js/storybook.js|
       assert_shell_receive :info, ~r|creating assets/css/storybook.css|
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Phx.Gen.StorybookTest do
       for _ <- 1..3, do: send(self(), {:mix_shell_input, :yes?, true})
       Storybook.run(["--no-tailwind"])
 
-      assert_file("storybook/components/my_component.story.exs")
+      assert_file("storybook/components/icon.story.exs")
       assert_file("storybook/my_page.story.exs")
       assert_file("lib/phx_live_storybook_web/storybook.ex")
 
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Phx.Gen.StorybookTest do
 
       assert_shell_receive :info, ~r|Starting storybook generation|
       assert_shell_receive :info, ~r|creating lib/phx_live_storybook_web/storybook.ex|
-      assert_shell_receive :info, ~r|creating storybook/components/my_component.story.exs|
+      assert_shell_receive :info, ~r|creating storybook/components/icon.story.exs|
       assert_shell_receive :info, ~r|creating storybook/my_page.story.exs|
       assert_shell_receive :info, ~r|creating assets/js/storybook.js|
       assert_shell_receive :info, ~r|creating assets/css/storybook.css|


### PR DESCRIPTION
When I use `mix phx.gen.storybook` it crash when I go to `storybook/components/my_component`.

```
Request: GET /storybook/components/my_component
** (exit) an exception was raised:
    ** (Phoenix.LiveView.HTMLTokenizer.ParseError) nofile:1:12: expected attribute name
        (phoenix_live_view 0.18.0) lib/phoenix_live_view/html_tokenizer.ex:339: Phoenix.LiveView.HTMLTokenizer.handle_attribute/5
        (phoenix_live_view 0.18.0) lib/phoenix_live_view/html_engine.ex:231: Phoenix.LiveView.HTMLEngine.handle_text/3
        (eex 1.14.0) lib/eex/compiler.ex:311: EEx.Compiler.generate_buffer/4
        (phx_live_storybook 0.4.0) lib/phx_live_storybook/rendering/component_renderer.ex:261: PhxLiveStorybook.Rendering.ComponentRenderer.render_component_heex/3
        (phx_live_storybook 0.4.0) lib/phx_live_storybook/live/story_live.ex:317: anonymous fn/5 in PhxLiveStorybook.StoryLive.render_content/3
...
```

It looks like it expects a named function.

I replaced the anonymous function by a named function in the generated component template and it solved the issue.