### PR TITLE
Fix user icon placement for StoryEntry in sidebar

### DIFF
--- a/lib/phx_live_storybook/live/sidebar.ex
+++ b/lib/phx_live_storybook/live/sidebar.ex
@@ -152,7 +152,7 @@ defmodule PhxLiveStorybook.Sidebar do
 
   defp story_class(current_path, story_path) do
     story_class =
-      "lsb -lsb-ml-[12px] lsb-block lsb-border-l lsb-py-2 lg:lsb-py-1 lsb-pl-4 hover:lsb-border-indigo-600 hover:lsb-text-indigo-600 hover:lsb-border-l-1.5 lsb-group"
+      "lsb lsb-flex lsb-items-center -lsb-ml-[12px] lsb-block lsb-border-l lsb-py-2 lg:lsb-py-1 lsb-pl-4 hover:lsb-border-indigo-600 hover:lsb-text-indigo-600 hover:lsb-border-l-1.5 lsb-group"
 
     if current_path == story_path do
       story_class <> " lsb-font-bold lsb-border-indigo-600 lsb-text-indigo-700 lsb-border-l-1.5"


### PR DESCRIPTION
This PR fixes the icon placement by adding a couple of classes which are also used for the folder icons.

Closes #118
