### PR TITLE
add :live_session and :as options

### DIFF
--- a/lib/phx_live_storybook/router.ex
+++ b/lib/phx_live_storybook/router.ex
@@ -32,6 +32,10 @@ defmodule PhxLiveStorybook.Router do
       books in the same router.
     * `:as` - Allows you to set the route helper name. Defaults to
       `:live_storybook`.
+    * `:pipeline` - Set to `false` if you don't want a router pipeline to be
+      created. This is useful if you want to define your own
+      `:storybook_browser` pipeline, or if you mount multiple story books, in
+      which case the pipeline only has to be defined once. Defaults to `true`.
 
   ## Usage
 
@@ -52,6 +56,7 @@ defmodule PhxLiveStorybook.Router do
       opts
       |> Keyword.put(:application_router, __CALLER__.module)
       |> Keyword.put_new(:as, :live_storybook)
+      |> Keyword.put_new(:pipeline, true)
 
     session_name_opt = Keyword.get(opts, :session_name, :live_storybook)
     session_name_iframe_opt = :"#{session_name_opt}_iframe"
@@ -60,10 +65,12 @@ defmodule PhxLiveStorybook.Router do
       scope path, alias: false, as: false do
         import Phoenix.LiveView.Router, only: [live: 4, live_session: 3]
 
-        pipeline :storybook_browser do
-          plug(:accepts, ["html"])
-          plug(:fetch_session)
-          plug(:protect_from_forgery)
+        if Keyword.fetch!(opts, :pipeline) do
+          pipeline :storybook_browser do
+            plug(:accepts, ["html"])
+            plug(:fetch_session)
+            plug(:protect_from_forgery)
+          end
         end
 
         scope path: "/" do

--- a/test/phx_live_storybook/router_test.exs
+++ b/test/phx_live_storybook/router_test.exs
@@ -20,6 +20,22 @@ defmodule PhxLiveStorybook.RouterTest do
                "/storybook/iframe/components/button"
     end
 
+    test "generates helper for home when :as option is passed" do
+      assert Routes.admin_live_storybook_path(build_conn(), :root) == "/admin/storybook"
+    end
+
+    test "generates helper for story when :as option is passed" do
+      assert Routes.admin_live_storybook_path(build_conn(), :story, ["components", "button"]) ==
+               "/admin/storybook/components/button"
+    end
+
+    test "generates helper for story iframe when :as option is passed" do
+      assert Routes.admin_live_storybook_path(build_conn(), :story_iframe, [
+               "components",
+               "button"
+             ]) == "/admin/storybook/iframe/components/button"
+    end
+
     test "raises when backend_module is missing" do
       assert_raise(RuntimeError, fn ->
         defmodule NoBackendModuleRouter do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -50,6 +50,15 @@ defmodule PhxLiveStorybook.TestRouter do
     otp_app: :phx_live_storybook,
     backend_module: PhxLiveStorybook.TestStorybook
   )
+
+  scope "/admin" do
+    live_storybook("/storybook",
+      otp_app: :phx_live_storybook,
+      backend_module: PhxLiveStorybook.TestStorybook,
+      session_name: :live_storybook_admin,
+      as: :admin_live_storybook
+    )
+  end
 end
 
 for endpoint <- [

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -56,7 +56,8 @@ defmodule PhxLiveStorybook.TestRouter do
       otp_app: :phx_live_storybook,
       backend_module: PhxLiveStorybook.TestStorybook,
       session_name: :live_storybook_admin,
-      as: :admin_live_storybook
+      as: :admin_live_storybook,
+      pipeline: false
     )
   end
 end


### PR DESCRIPTION
This adds a `session_name` option for the live session and an `as` option for the route helper name. I don't know how you would make it work with the `as` option passed to the surrounding scope.

There is one problem: The `storybook_browser` pipeline is defined any time `live_storybook` is called in the router. This leads to a warning:

```
warning: this clause for storybook_browser/2 cannot match because a previous clause at line 49 always matches
  test/test_helper.exs:55
```

How do you want to solve this? Remove the pipeline from the macro and instruct users to add it manually?

resolves #126