### PR TITLE
pass connect params to page story

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,7 @@ let liveSocket = new LiveSocket(socketPath, Socket, {
   params: (liveViewName) => {
     return {
       _csrf_token: csrfToken,
+      extra: window.storybook.Params,
     };
   },
 });

--- a/guides/sandboxing.md
+++ b/guides/sandboxing.md
@@ -16,17 +16,18 @@ This guide will explain:
 
 `PhxLiveStorybook` runs with Phoenix LiveView and therefore requires its `LiveSocket`.
 This LiveSocket is the same used by your components: you just need to inject it with your
-own `Hooks` and `Uploaders`.
+own `Hooks`, `Params` and `Uploaders`.
 
-To do so, create a JS file that will declare your `Hooks` and `Uploaders` and set them in
+To do so, create a JS file that will declare your `Hooks`, `Params` and `Uploaders` and set them in
 `window.storybook`. This script will be loaded immediately before the storybook's script.
 
 ```javascript
 // assets/js/my_components.js
 import * as Hooks from "./hooks";
+import * as Params from "./params";
 import * as Uploaders from "./uploaders";
 (function () {
-  window.storybook = { Hooks, Uploaders };
+  window.storybook = { Hooks, Params, Uploaders };
 })();
 ```
 
@@ -35,6 +36,9 @@ file.
 
 You can also use this script to inject whatever content you want into document `HEAD`, such as
 external scripts.
+
+The `Params` will be available in page stories as `connect_params` assign.
+There is currently no way to access them in component or live component stories.
 
 ## 2. How is the storybook styled?
 

--- a/guides/setup.md
+++ b/guides/setup.md
@@ -64,16 +64,17 @@ app and the storybook.
 
 In this README, we use `assets/css/storybook.css` as an example.
 
-If your components require any hooks or custom uploaders, declare them as such in a new JS bundle:
+If your components require any hooks or custom uploaders, or if your pages require connect parameters, declare them as such in a new JS bundle:
 
 ```javascript
 // assets/js/storybook.js
 
 import * as Hooks from "./hooks";
+import * as Params from "./params";
 import * as Uploaders from "./uploaders";
 
 (function () {
-  window.storybook = { Hooks, Uploaders };
+  window.storybook = { Hooks, Params, Uploaders };
 })();
 ```
 

--- a/lib/phx_live_storybook/live/story_live.ex
+++ b/lib/phx_live_storybook/live/story_live.ex
@@ -15,6 +15,7 @@ defmodule PhxLiveStorybook.StoryLive do
   import PhxLiveStorybook.NavigationHelpers
 
   def mount(_params, session, socket) do
+    connect_params = get_connect_params(socket)["extra"]
     playground_topic = "playground-#{inspect(self())}"
     event_logs_topic = "event_logs:#{inspect(self())}"
 
@@ -32,7 +33,8 @@ defmodule PhxLiveStorybook.StoryLive do
        playground_error: nil,
        playground_preview_pid: nil,
        playground_topic: playground_topic,
-       fa_plan: backend_module.config(:font_awesome_plan, :free)
+       fa_plan: backend_module.config(:font_awesome_plan, :free),
+       connect_params: connect_params
      )}
   end
 
@@ -367,7 +369,7 @@ defmodule PhxLiveStorybook.StoryLive do
 
     ~H"""
     <div class={"lsb lsb-pb-12 #{LayoutView.sandbox_class(@socket, assigns)}"}>
-      <%= @story.render(%{__changed__: %{}, tab: @tab, theme: @theme}) |> to_raw_html() %>
+      <%= @story.render(%{__changed__: %{}, tab: @tab, theme: @theme, connect_params: @connect_params}) |> to_raw_html() %>
     </div>
     """
   end

--- a/priv/templates/phx.gen.storybook/storybook.js
+++ b/priv/templates/phx.gen.storybook/storybook.js
@@ -1,8 +1,11 @@
-// If your components require any hooks or custom uploaders, uncomment the following lines and declare them as such:
-// 
+// If your components require any hooks or custom uploaders, or if your pages
+// require connect parameters, uncomment the following lines and declare them as
+// such:
+//
 // import * as Hooks from "./hooks";
+// import * as Params from "./params";
 // import * as Uploaders from "./uploaders";
 
 // (function () {
-//   window.storybook = { Hooks, Uploaders };
+//   window.storybook = { Hooks, Params, Uploaders };
 // })();


### PR DESCRIPTION
This allows a user to pass live socket connect parameters to page stories. I only need this for pages, not components. If someone needs this for components as well, we could change the `variations/0` to `variations/1`, but since that would be a breaking change and it's unclear whether anybody needs it, I wouldn't do that now.

resolves #129 