### PR TITLE
Change Slot.id type from String to atom

### DIFF
--- a/lib/phx_live_storybook/stories/slot.ex
+++ b/lib/phx_live_storybook/stories/slot.ex
@@ -17,7 +17,7 @@ defmodule PhxLiveStorybook.Stories.Slot do
   require Logger
 
   @type t :: %__MODULE__{
-          id: String.t(),
+          id: atom(),
           doc: String.t(),
           required: boolean
         }


### PR DESCRIPTION
@cblavier I am not 100% sure about this, but we are using atom for `slot.id`. The same with any other id in variations, variation group, and attr. So I guess we should change the type to atom for slots as well.

This prevents the warning:
```
Warning: Type mismatch for @callback slots/0 in PhxLiveStorybook.Story.ComponentBehaviour behaviour
Expected type:
[
  %PhxLiveStorybook.Stories.Slot{:doc => binary(), :id => binary(), :required => boolean()}
]

Actual type:
[%PhxLiveStorybook.Stories.Slot{:doc => <<_::72>>, :id => :tab, :required => false}, ...]
```