### PR TITLE
Update index callback return typespec

### DIFF
--- a/lib/phx_live_storybook/stories/index.ex
+++ b/lib/phx_live_storybook/stories/index.ex
@@ -40,7 +40,7 @@ defmodule PhxLiveStorybook.Index do
     @callback folder_name() :: nil | String.t()
     @callback folder_icon() :: nil | icon()
     @callback folder_open?() :: boolean()
-    @callback entry(String.t()) :: [key: String.t() | icon()]
+    @callback entry(String.t()) :: keyword(String.t() | icon())
   end
 
   @doc """


### PR DESCRIPTION
I was getting the following warning from Dialyzer from the generated `_root.index.exs` file:

```
storybook/_root.index.exs:10:callback_type_mismatch
Type mismatch for @callback entry/1 in PhxLiveStorybook.Index.IndexBehaviour behaviour.

Expected type:
[
  {:key,
   binary()
   | {:fa, binary()}
   | {:hero, binary()}
   | {:fa, binary(), atom()}
   | {:hero, binary(), atom()}
   | {:fa, binary(), atom(), binary()}
   | {:hero, binary(), atom(), binary()}}
]

Actual type:
[{:icon, {:fa, <<_::72>>, :thin}} | {:name, <<_::96>>}, ...]
```

The return type for the `entry` callback is `[key: String.t() | icon()]`, which means Dialyzer is looking for a keyword with the key `:key` that has a string or icon as the value.

I believe the intention behind the spec was that a key could be any atom and values could only be strings or icons. The typespec that describes this is:

```elixir
keyword(String.t() | icon())
```

However, in this PR I've opted to name the keys and the type of their expected values explicitly instead. I can switch to the `keyword(t)` definition if that'd be preferred.

Anyway, this will allow Storybook to be installed in apps that have dialyzer without any warnings now.