### PR TITLE
Fix @callback and reuse Icon's definition

### DIFF
--- a/lib/phx_live_storybook/icon.ex
+++ b/lib/phx_live_storybook/icon.ex
@@ -1,0 +1,11 @@
+defmodule PhxLiveStorybook.Icon do
+  @moduledoc """
+  Definitions of icon and valid icon providers to be used in specs and behaviours.
+  """
+  @type icon_provider :: :fa | :hero
+
+  @type t ::
+          {icon_provider(), String.t()}
+          | {icon_provider(), String.t(), atom}
+          | {icon_provider(), String.t(), atom, String.t()}
+end

--- a/lib/phx_live_storybook/stories/index.ex
+++ b/lib/phx_live_storybook/stories/index.ex
@@ -30,17 +30,12 @@ defmodule PhxLiveStorybook.Index do
 
   defmodule IndexBehaviour do
     @moduledoc false
-
-    @type icon_provider :: :fa | :hero
-    @type icon ::
-            {icon_provider(), String.t()}
-            | {icon_provider(), String.t(), atom}
-            | {icon_provider(), String.t(), atom, String.t()}
+    alias PhxLiveStoryBook.Icon
 
     @callback folder_name() :: nil | String.t()
-    @callback folder_icon() :: nil | icon()
+    @callback folder_icon() :: nil | Icon.t()
     @callback folder_open?() :: boolean()
-    @callback entry(String.t()) :: keyword(String.t() | icon())
+    @callback entry(String.t()) :: keyword(String.t() | Icon.t())
   end
 
   @doc """

--- a/lib/phx_live_storybook/stories/story.ex
+++ b/lib/phx_live_storybook/stories/story.ex
@@ -83,9 +83,9 @@ defmodule PhxLiveStorybook.Story do
   ```
   """
 
+  alias PhxLiveStorybook.Icon
   alias PhxLiveStorybook.Stories.{Attr, Slot, Variation, VariationGroup}
   alias PhxLiveStorybook.Stories.StoryComponentSource
-  alias PhxLiveStorybook.Icon
 
   defmodule StoryBehaviour do
     @moduledoc false

--- a/lib/phx_live_storybook/stories/story.ex
+++ b/lib/phx_live_storybook/stories/story.ex
@@ -71,8 +71,8 @@ defmodule PhxLiveStorybook.Story do
 
     def navigation do
       [
-        {:tab_one, "Tab One", "tab-icon"},
-        {:tab_two, "Tab Two", "tab-icon"}
+        {:tab_one, "Tab One", {:fa, "book"}},
+        {:tab_two, "Tab Two", {:fa, "cake", :solid}}
       ]
     end
 
@@ -85,6 +85,7 @@ defmodule PhxLiveStorybook.Story do
 
   alias PhxLiveStorybook.Stories.{Attr, Slot, Variation, VariationGroup}
   alias PhxLiveStorybook.Stories.StoryComponentSource
+  alias PhxLiveStorybook.Icon
 
   defmodule StoryBehaviour do
     @moduledoc false
@@ -122,7 +123,7 @@ defmodule PhxLiveStorybook.Story do
   defmodule PageBehaviour do
     @moduledoc false
 
-    @callback navigation() :: [{atom(), String.t(), String.t()}]
+    @callback navigation() :: [{atom(), String.t(), Icon.t()}]
     @callback render(map()) :: %Phoenix.LiveView.Rendered{}
   end
 


### PR DESCRIPTION
Our dialyzer was complaining that generated `navigation` doesn't match the `@callback`'s return type defined in behaviour.

I couldn't find the right place where would this icon `@type` definition fit best so created a module 🤷🏻‍♂️ 
please, let me know if there is a better place for this