### PR TITLE
Fix function_exported? check on Elixir 1.19

### DIFF
--- a/lib/phoenix_storybook/exs_compiler.ex
+++ b/lib/phoenix_storybook/exs_compiler.ex
@@ -37,7 +37,10 @@ defmodule PhoenixStorybook.ExsCompiler do
       Enum.find(
         modules,
         Enum.at(modules, 0),
-        &function_exported?(&1, :storybook_type, 0)
+        fn module ->
+          Code.ensure_compiled!(module)
+          function_exported?(module, :storybook_type, 0)
+        end
       )
     after
       Code.put_compiler_option(:ignore_module_conflict, original_ignore_module_conflict)


### PR DESCRIPTION
The module search after compiling a file is not working properly with Elixir 1.19. `function_exported?/3` with this new version is always returning `false`, so `do_compile_exs!` always returns the first module in the list, which causes issues if the file contains multiple modules.

Issue similar to https://github.com/elixir-lang/elixir/issues/14578 