### PR TITLE
Apply storybook theme change to component sandbox

### DIFF
--- a/assets/js/lib/color_mode_hook.js
+++ b/assets/js/lib/color_mode_hook.js
@@ -46,8 +46,10 @@ export const ColorModeHook = {
     if ("colorMode" in document.documentElement.dataset) {
       if (mode === "dark") {
         document.documentElement.classList.add("psb:dark");
+        document.documentElement.setAttribute("data-theme", "dark");
       } else {
         document.documentElement.classList.remove("psb:dark");
+        document.documentElement.removeAttribute("data-theme");
       }
     }
   },

--- a/assets/js/lib/color_mode_hook.js
+++ b/assets/js/lib/color_mode_hook.js
@@ -49,7 +49,7 @@ export const ColorModeHook = {
         document.documentElement.setAttribute("data-theme", "dark");
       } else {
         document.documentElement.classList.remove("psb:dark");
-        document.documentElement.removeAttribute("data-theme");
+        document.documentElement.setAttribute("data-theme", "light");
       }
     }
   },


### PR DESCRIPTION
Switching to dark mode inside the Storybook was not showing the dark styles for Daisy UI helpers.
Simply because Daisy UI tracks themes with the `data-theme` attribute on the `<html>` element.
This PR makes sure the `data-theme` attribute is handled within the `toggleColorModeClass` function.

Update on second commit:
When the default theme on OS is dark (mine is Windows 11 right now), the Storybook itself recognizes the dark mode and  applies it. If I simply remove the `data-theme`along with the `psb:dark` class, then Daisy UI will have no way of knowing that it has to be in dark mode by default. So you end up with light theme while your system's default is black. So we need to be explicit about the `data-theme` inside the Storybook routes.