### PR TITLE
Support data-* attribute for themes_strategies

### DIFF
--- a/guides/theming.md
+++ b/guides/theming.md
@@ -8,8 +8,9 @@ possibilities are named _strategies_.
 The following strategies are available:
 
 1. _sandbox class_: set your theme as a CSS class, on the sandbox container, with a custom prefix
-2. _assign_: pass the theme as an assign to your components, with a custom key.
-3. _function_: call a custom module/function along with the current theme.
+2. _data attribute_ (`data_attribute`): set your theme on the sandbox container as a `data-*` attribute.
+3. _assign_: pass the theme as an assign to your components, with a custom key.
+4. _function_: call a custom module/function along with the current theme.
 
 Here is how you can use these strategies. In your `storybook.ex`:
 
@@ -17,6 +18,7 @@ Here is how you can use these strategies. In your `storybook.ex`:
 use PhoenixStorybook,
   themes_strategies: [
     sandbox_class: "prefix", # will set a class prefixed by `prefix-` on the sandbox container
+    data_attribute: "name", # will set data-name="theme" on the sandbox container
     assign: :theme,
     function: {MyApp.ThemeHelper, :register_theme}
   ]

--- a/lib/phoenix_storybook/helpers/theme_helpers.ex
+++ b/lib/phoenix_storybook/helpers/theme_helpers.ex
@@ -15,6 +15,13 @@ defmodule PhoenixStorybook.ThemeHelpers do
 
       attribute_name when is_binary(attribute_name) ->
         {String.to_atom("data-#{attribute_name}"), "#{theme}"}
+
+      attribute_name when is_atom(attribute_name) ->
+        {String.to_atom("data-#{Atom.to_string(attribute_name)}"), "#{theme}"}
+
+      attribute_name ->
+        raise ArgumentError,
+              "expected :data_attribute theme strategy to be a binary or atom, got: #{inspect(attribute_name)}"
     end
   end
 

--- a/lib/phoenix_storybook/helpers/theme_helpers.ex
+++ b/lib/phoenix_storybook/helpers/theme_helpers.ex
@@ -8,6 +8,16 @@ defmodule PhoenixStorybook.ThemeHelpers do
     end
   end
 
+  def theme_sandbox_data_attribute(backend_module, theme) do
+    case theme_strategy(backend_module, :data_attribute) do
+      nil ->
+        nil
+
+      attribute_name when is_binary(attribute_name) ->
+        {String.to_atom("data-#{attribute_name}"), "#{theme}"}
+    end
+  end
+
   def theme_assign(backend_module, theme) do
     case theme_strategy(backend_module, :assign) do
       nil -> nil

--- a/lib/phoenix_storybook/live/story/component_iframe_live.ex
+++ b/lib/phoenix_storybook/live/story/component_iframe_live.ex
@@ -118,7 +118,15 @@ defmodule PhoenixStorybook.Story.ComponentIframeLive do
         )}
       <% else %>
         <% {classes, iframe_opts} = Keyword.pop(@iframe_opts, :class) %>
-        <div {iframe_opts} class={[classes, @color_mode_class]}>
+        <div
+          {iframe_opts}
+          class={[classes, @color_mode_class]}
+          {LayoutView.sandbox_attributes(
+            @socket,
+            {:div, @iframe_opts},
+            assigns
+          )}
+        >
           {ComponentRenderer.render(@context)}
         </div>
       <% end %>

--- a/lib/phoenix_storybook/live/story/playground_preview_live.ex
+++ b/lib/phoenix_storybook/live/story/playground_preview_live.ex
@@ -118,8 +118,12 @@ defmodule PhoenixStorybook.Story.PlaygroundPreviewLive do
           ),
           @color_mode_class
         ]}
-        ,
         style="display: flex; flex-direction: column; justify-content: center; align-items: center; margin: 0; gap: 5px; height: 100%; width: 100%; padding: 10px;"
+        {LayoutView.sandbox_attributes(
+          @socket,
+          LayoutView.normalize_story_container(@story.container()),
+          assigns
+        )}
       >
         {ComponentRenderer.render(@context)}
       </div>

--- a/lib/phoenix_storybook/live/story/variations.ex
+++ b/lib/phoenix_storybook/live/story/variations.ex
@@ -136,6 +136,11 @@ defmodule PhoenixStorybook.Story.Variations do
                     LayoutView.sandbox_class(@socket, container_with_opts, assigns),
                     @color_mode_class
                   ]}
+                  {LayoutView.sandbox_attributes(
+                    @socket,
+                    container_with_opts,
+                    assigns
+                  )}
                   {@sandbox_attributes}
                 >
                   {ComponentRenderer.render(rendering_context)}

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -420,7 +420,10 @@ defmodule PhoenixStorybook.StoryLive do
 
   defp render_content(:page, assigns) do
     ~H"""
-    <div class={LayoutView.sandbox_class(@socket, {:div, class: "psb psb:pb-12"}, assigns)}>
+    <div
+      class={LayoutView.sandbox_class(@socket, {:div, class: "psb psb:pb-12"}, assigns)}
+      {LayoutView.sandbox_attributes(@socket, {:div, class: "psb psb:pb-12"}, assigns)}
+    >
       {@story.render(%{__changed__: %{}, tab: @tab, theme: @theme})
       |> to_raw_html()}
     </div>
@@ -435,12 +438,15 @@ defmodule PhoenixStorybook.StoryLive do
       session: %{"theme" => theme},
       container:
         {:div,
-         class:
-           LayoutView.sandbox_class(
-             assigns.socket,
-             {:div, class: ["psb psb:pb-12", assigns[:color_mode_class]]},
-             assigns
-           )}
+         [
+           class:
+             LayoutView.sandbox_class(
+               assigns.socket,
+               {:div, class: ["psb psb:pb-12", assigns[:color_mode_class]]},
+               assigns
+             )
+         ] ++
+           LayoutView.sandbox_attributes(assigns.socket, {:div, class: "psb psb:pb-12"}, assigns)}
     )
   end
 

--- a/lib/phoenix_storybook/templates/layout/root_iframe.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root_iframe.html.heex
@@ -59,7 +59,11 @@
     if assigns[:story],
       do: normalize_story_container(assigns[:story].container()),
       else: {:div, []} %>
-  <body class={sandbox_class(@conn, container, assigns)} style="margin: 0;">
+  <body
+    class={sandbox_class(@conn, container, assigns)}
+    style="margin: 0;"
+    {sandbox_attributes(@conn, container, assigns)}
+  >
     {@inner_content}
   </body>
 </html>

--- a/lib/phoenix_storybook/views/layout_view.ex
+++ b/lib/phoenix_storybook/views/layout_view.ex
@@ -196,6 +196,13 @@ defmodule PhoenixStorybook.LayoutView do
      "psb:opacity-0 psb:scale-95"}
   end
 
+  def sandbox_attributes(_conn_or_socket, _container, %{theme: nil}), do: []
+
+  def sandbox_attributes(conn_or_socket, _container, %{theme: theme}) do
+    backend_module = backend_module(conn_or_socket)
+    List.wrap(ThemeHelpers.theme_sandbox_data_attribute(backend_module, theme))
+  end
+
   def sandbox_class(conn_or_socket, container, %{theme: nil}) do
     main_sandbox_class(conn_or_socket, container)
   end

--- a/test/phoenix_storybook/helpers/theme_helpers_test.exs
+++ b/test/phoenix_storybook/helpers/theme_helpers_test.exs
@@ -15,6 +15,18 @@ defmodule PhoenixStorybook.ThemeHelpersTest do
     end
   end
 
+  defmodule DataAttributeBackend do
+    def config(:themes_strategies, default) do
+      Keyword.put(default, :data_attribute, "test-theme")
+    end
+  end
+
+  defmodule DataAttributeNilBackend do
+    def config(:themes_strategies, default) do
+      Keyword.put(default, :data_attribute, nil)
+    end
+  end
+
   defmodule AssignBinaryBackend do
     def config(:themes_strategies, default) do
       Keyword.put(default, :assign, "theme")
@@ -45,6 +57,15 @@ defmodule PhoenixStorybook.ThemeHelpersTest do
 
   test "theme_sandbox_class prefixes theme when strategy exists" do
     assert ThemeHelpers.theme_sandbox_class(SandboxPrefixBackend, :default) == "sandbox-default"
+  end
+
+  test "theme_sandbox_data_attribute nil when no sandbox strategy" do
+    assert ThemeHelpers.theme_sandbox_data_attribute(DataAttributeNilBackend, :default) == nil
+  end
+
+  test "theme_sandbox_data_attribute returns configured data attribute pair as tuple" do
+    assert ThemeHelpers.theme_sandbox_data_attribute(DataAttributeBackend, :default) ==
+             {:"data-test-theme", "default"}
   end
 
   test "theme_assign returns nil when no assign strategy" do

--- a/test/phoenix_storybook/views/layout_view_test.exs
+++ b/test/phoenix_storybook/views/layout_view_test.exs
@@ -101,6 +101,33 @@ defmodule PhoenixStorybook.LayoutViewTest do
     def find_entry_by_path(_path), do: nil
   end
 
+  defmodule TestBackendWithSandboxDataAttribute do
+    def config(key, default \\ nil) do
+      Keyword.get(
+        [
+          sandbox_class: "root-sandbox",
+          themes_strategies: [data_attribute: "test-theme"],
+          color_mode_sandbox_light_class: "light"
+        ],
+        key,
+        default
+      )
+    end
+  end
+
+  defmodule TestBackendWithSandboxCustomDataAttribute do
+    def config(key, default \\ nil) do
+      Keyword.get(
+        [
+          sandbox_class: "root-sandbox",
+          themes_strategies: [data_attribute: "appearance"]
+        ],
+        key,
+        default
+      )
+    end
+  end
+
   defmodule DummyEndpoint do
     def script_name, do: ["storybook"]
   end
@@ -280,6 +307,52 @@ defmodule PhoenixStorybook.LayoutViewTest do
     refute Enum.member?(no_theme, "theme-default")
     assert Enum.member?(with_theme, "theme-default")
     assert Enum.member?(with_theme, "root-sandbox")
+  end
+
+  test "sandbox_attributes uses data_attribute strategy with configured key" do
+    conn = build_test_conn(TestBackendWithSandboxDataAttribute)
+
+    attrs =
+      LayoutView.sandbox_attributes(conn, {:div, [class: "container"]}, %{
+        theme: :default,
+        color_mode: nil
+      })
+
+    assert Keyword.get(attrs, :"data-test-theme") == "default"
+  end
+
+  test "sandbox_attributes returns empty list when theme is nil" do
+    conn = build_test_conn(TestBackendWithSandboxDataAttribute)
+
+    attrs =
+      LayoutView.sandbox_attributes(conn, {:div, [class: "container"]}, %{
+        theme: nil
+      })
+
+    assert attrs == []
+  end
+
+  test "sandbox_attributes returns empty list when data_attribute strategy is not configured" do
+    conn = build_test_conn(TestBackend)
+
+    attrs =
+      LayoutView.sandbox_attributes(conn, {:div, [class: "container"]}, %{
+        theme: :default
+      })
+
+    assert attrs == []
+  end
+
+  test "sandbox_attributes supports custom data attribute names for themes" do
+    conn = build_test_conn(TestBackendWithSandboxCustomDataAttribute)
+
+    attrs =
+      LayoutView.sandbox_attributes(conn, {:div, [class: "container"]}, %{
+        theme: :default,
+        color_mode: nil
+      })
+
+    assert Keyword.get(attrs, :"data-appearance") == "default"
   end
 
   test "normalize_story_container sets defaults for div and iframe" do


### PR DESCRIPTION
Implements the requested feature in #792 

This pull request adds support for a new theme strategy that applies the selected theme as a `data-*` attribute on the sandbox container. It introduces the `data_attribute` strategy, updates documentation, and modifies the rendering logic to include these attributes when configured. Tests are also added to ensure correct behavior for the new strategy, including custom attribute names and nil cases.

**New theme strategy: data attribute**

* Added support for a `data_attribute` theme strategy, allowing the theme to be set as a `data-*` attribute on the sandbox container. Updated documentation in `theming.md` to describe this new strategy and its usage.
* Implemented `theme_sandbox_data_attribute/2` in `ThemeHelpers` to generate the appropriate attribute tuple based on configuration.
* Updated `LayoutView.sandbox_attributes/3` to include the data attribute when the theme and strategy are configured.

**Integration into rendering**

* Modified all relevant LiveView and template files (`component_iframe_live.ex`, `playground_preview_live.ex`, `variations.ex`, `story_live.ex`, `root_iframe.html.heex`) to call `sandbox_attributes` and include the data attribute in the rendered HTML containers. [[1]](diffhunk://#diff-2a81d09265d176deb447af4f55438e19134ce6fdeac5b98fae7e91238377bb0dL121-R129) [[2]](diffhunk://#diff-7d7595c6d7400a53168a663482968ebe2f35250a67d9c993554dbd0be3495de0L121-R126) [[3]](diffhunk://#diff-3475757c1f7d244880536a0519391dc1ca3dea6724f47797ce6422afed3afef1R139-R143) [[4]](diffhunk://#diff-abb039fdfe7053d7dadbdec3eeb2b18fc37a53dc390bd43369e4b7dc9f25bdc9L423-R426) [[5]](diffhunk://#diff-abb039fdfe7053d7dadbdec3eeb2b18fc37a53dc390bd43369e4b7dc9f25bdc9R441-R449) [[6]](diffhunk://#diff-15a33c2f7187cb5bf22314d2f684e9c4a6c7d8ac70fa57ae9d29a4a89bbd2335L62-R66)

**Testing**

* Added new test modules and cases to verify correct behavior for the `data_attribute` strategy, including cases for nil values and custom attribute names in both `ThemeHelpersTest` and `LayoutViewTest`. [[1]](diffhunk://#diff-161bfc64908407dac6a331003f76e1c9cf2efd0e4b357ebc4d91170ace38e153R18-R29) [[2]](diffhunk://#diff-161bfc64908407dac6a331003f76e1c9cf2efd0e4b357ebc4d91170ace38e153R62-R70) [[3]](diffhunk://#diff-122df2bed3ba0846f8f01681a37dee4560bd2b08b26411b503c868b74e2fa266R104-R130) [[4]](diffhunk://#diff-122df2bed3ba0846f8f01681a37dee4560bd2b08b26411b503c868b74e2fa266R312-R357)