### PR TITLE
docs: add docstring to warnReservedHooks function

### DIFF
--- a/assets/js/lib/warn_reserved_hooks.js
+++ b/assets/js/lib/warn_reserved_hooks.js
@@ -1,3 +1,8 @@
+/**
+ * Warns users if they are using reserved hook names that will be overridden.
+ * @param {string[]} reservedNames - Array of reserved hook names.
+ * @param {Object|null|undefined} userHooks - Object containing user-defined hooks.
+ */
 export function warnReservedHooks(reservedNames, userHooks) {
   for (const name of Object.keys(userHooks ?? {})) {
     if (reservedNames.includes(name)) {


### PR DESCRIPTION
### 问题背景
公共函数 `warnReservedHooks` 缺少文档注释，这降低了代码的可读性和维护性。开发者可能难以快速理解函数的作用、参数要求和使用场景，影响开发效率和代码协作。

### 修改内容
- 为 `warnReservedHooks` 函数添加了 JSDoc 文档注释。
- 注释包括函数描述（警告用户保留钩子名称将被覆盖）、参数 `reservedNames`（字符串数组）和 `userHooks`（用户定义钩子对象，可为空或未定义）的类型和说明。
- 这提升了代码的自文档化能力，使函数意图更清晰，便于新贡献者和维护者理解和维护代码。

### 验证方式
- 修改仅限于文档注释，未改变函数功能或外部行为。
- 通过运行现有测试套件（如有）确保没有引入错误。
- 手动检查注释准确反映函数逻辑。

### 其他信息
- 没有 breaking changes，所有现有 API 和行为保持不变。
- 文档已通过注释更新，无需额外文档修改。
- 已知限制：无。